### PR TITLE
Add lein in a docker container.

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM lynxtp/openjdk-jdk:8
+MAINTAINER "Tom Vaughan <tvaughan@lynxtp.com>"
+
+RUN curl -sL -o /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/2.6.1/bin/lein \
+    && chmod a+x /usr/local/bin/lein
+
+ENV LEIN_HOME /srv/lein
+ENV LEIN_ROOT 1
+
+ENV LEIN_REPL_HOST 0.0.0.0
+ENV LEIN_REPL_PORT 5309
+
+EXPOSE $LEIN_REPL_PORT
+
+CMD ["lein"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY = all build
+
+all: build
+
+build:
+	@docker-compose -f lein.yml build --pull

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# docker-lein
-leiningen in a docker container
+## Usage
+
+First, download and install the
+[Docker Toolbox](https://www.docker.com/products/docker-toolbox).
+
+To build the container from scratch, run `make`, or skip this step to use a
+pre-built container from the
+[Docker Hub](https://hub.docker.com/r/lynxtp/lein).
+
+To run the [lein command-line tool](http://leiningen.org), run `./lein`. The
+lein command will have access to the current working directory and all
+subdirectories.

--- a/lein
+++ b/lein
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+# -*- coding: utf-8; mode: sh -*-
+HERE=$(dirname $0)
+SERVICE=lein
+CMD=$(basename $0)
+docker-compose -f $HERE/$SERVICE.yml run --service-ports $SERVICE $CMD "$@"
+exit 0

--- a/lein.yml
+++ b/lein.yml
@@ -1,0 +1,16 @@
+version: "2"
+services:
+  lein:
+    build:
+      context: .
+    image: lynxtp/lein:2.6.1
+    ports:
+      - "5309:5309"
+    volumes_from:
+      - lein-volume
+    volumes:
+      - $PWD:/mnt/workdir
+  lein-volume:
+    image: lynxtp/ubuntu:15.10
+    volumes:
+      - /srv/lein


### PR DESCRIPTION
Fixes #1. This pull-request will be merged into master. Once this is accepted we'll push the tag `2.6.1` to match lein's version. Our [automated builds](https://hub.docker.com/r/lynxtp/lein/~/settings/automated-builds) create containers with version numbers that match github tags. This means that each time we push a new tag a new container will be built and its version number will be the same as the github tag.

Depends on https://github.com/lynxtp/docker-openjdk-jdk/pull/3
